### PR TITLE
feat: consume AgendaGijon API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 fastapi[standard]~=0.112.0
+pydantic==2.8.2
+requests==2.32.3

--- a/src/controller/event_controller.py
+++ b/src/controller/event_controller.py
@@ -1,9 +1,12 @@
 from typing import List
 
 from src.model.event import Event
+from src.service.api_consumer_service import ApiConsumerService
+from src.service.parser import AgendaGijonParser
 
 
 class EventController:
     @staticmethod
     async def get_events() -> List[Event]:
-        return []
+        url = "https://drupal.gijon.es/es/listado_eventos_tes3/?_format=json"
+        return ApiConsumerService.consume(url, AgendaGijonParser())

--- a/src/model/event.py
+++ b/src/model/event.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, AnyUrl
@@ -5,11 +6,11 @@ from pydantic import BaseModel, AnyUrl
 
 class Event(BaseModel):
     title: str
-    description: str
+    description: Optional[str] = None
     location: Optional[str] = None
-    start_date: str
-    end_date: str
-    type: str
+    start_date: datetime
+    end_date: datetime
+    type: Optional[str] = None
     provider: str
-    url: AnyUrl
-    image: Optional[str] = None
+    external_url: AnyUrl  # para validar que es una url correcta
+    image_url: Optional[AnyUrl] = None

--- a/src/service/api_consumer_service.py
+++ b/src/service/api_consumer_service.py
@@ -1,0 +1,14 @@
+from typing import List
+
+import requests
+
+from src.model.event import Event
+from src.service.parser import EventParser
+
+
+class ApiConsumerService:
+    @staticmethod
+    def consume(url: str, parser: EventParser) -> List[Event]:
+        response = requests.get(url)
+        events: List[Event] = list(map(lambda raw_event: parser.parse(raw_event), response.json()))
+        return events

--- a/src/service/parser/__init__.py
+++ b/src/service/parser/__init__.py
@@ -1,0 +1,4 @@
+from .agenda_gijon_parser import AgendaGijonParser
+from .event_parser import EventParser
+
+__all__ = ["EventParser", "AgendaGijonParser"]

--- a/src/service/parser/agenda_gijon_parser.py
+++ b/src/service/parser/agenda_gijon_parser.py
@@ -1,0 +1,25 @@
+import re
+from datetime import datetime
+
+from src.model.event import Event
+from src.service.parser.event_parser import EventParser
+
+
+class AgendaGijonParser(EventParser):
+    date_re = re.compile(r"(\d{4}-\d{2}-\d{2})")
+    base_external_url = "https://www.gijon.es/es/eventos"
+    base_image_url = "https://www.gijon.es"
+
+    def parse(self, raw_event: dict):
+        dates = self.date_re.findall(raw_event["fechas"])
+        start_date = datetime.strptime(dates[0], "%Y-%m-%d")
+        end_date = start_date
+        if len(dates) > 1:
+            end_date = datetime.strptime(dates[1], "%Y-%m-%d")
+        return Event(title=raw_event["titulo"],
+                     location="Gijón",
+                     start_date=start_date,
+                     end_date=end_date,
+                     provider="Agenda Gijón",
+                     external_url=f"{self.base_external_url}{raw_event['alias']}",
+                     image_url=f"{self.base_image_url}{raw_event['imagen']}")

--- a/src/service/parser/event_parser.py
+++ b/src/service/parser/event_parser.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+
+
+class EventParser(ABC):
+    @abstractmethod
+    def parse(self, raw_event: dict):
+        raise NotImplementedError()


### PR DESCRIPTION
- Se consumen los eventos de la api de agenda de gijón (https://www.gijon.es/es/eventos?etiquetas=)
- De manera temporal se pueden obtener consultando al endpoint `/events`